### PR TITLE
Updating dependencies

### DIFF
--- a/step-0/Cargo.toml
+++ b/step-0/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/step-1/Cargo.toml
+++ b/step-1/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 
 [dependencies.parity-hash]
 version = "1"

--- a/step-2/Cargo.toml
+++ b/step-2/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 pwasm-abi = "0.1"
 pwasm-abi-derive = "0.1"
 

--- a/step-3/Cargo.toml
+++ b/step-3/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 pwasm-abi = "0.1"
 pwasm-abi-derive = "0.1"
 

--- a/step-4/Cargo.toml
+++ b/step-4/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 pwasm-abi = "0.1"
 pwasm-abi-derive = "0.1"
 

--- a/step-5/Cargo.toml
+++ b/step-5/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Alexey Frolov <alexey@parity.io>"]
 
 [dependencies]
-pwasm-std = "0.7"
-pwasm-ethereum = "0.4"
+pwasm-std = "0.9.0"
+pwasm-ethereum = "0.5.1"
 pwasm-abi = "0.1"
 pwasm-abi-derive = "0.1"
 


### PR DESCRIPTION
Updated to include the newest `pwasm-std` and `pwasm-ethereum` versions in order to cope with the breaking `panic_implementation` changes in nightly (see [`panic_fmt` language item removed in favor of #[panic_implementation]](https://users.rust-lang.org/t/psa-breaking-change-panic-fmt-language-item-removed-in-favor-of-panic-implementation/17875))